### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,12 +2,19 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
     "typecheck": {
-      "outputs": ["{projectRoot}/out-tsc"],
-      "dependsOn": ["^typecheck"]
+      "outputs": [
+        "{projectRoot}/out-tsc"
+      ],
+      "dependsOn": [
+        "^typecheck"
+      ]
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
@@ -70,6 +77,7 @@
       }
     }
   },
-  "nxCloudId": "677c180c2f196d703cd4669d",
-  "bump": 6
+  "nxCloudId": "679c877cd5cf20060aafed7b",
+  "bump": 6,
+  "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://staging.nx.app/orgs/62d013d4d26f260059f7765e/workspaces/679c877cd5cf20060aafed7b

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.